### PR TITLE
MAGN-7224 Move ZeroTouchEssentials library into Dynamo repository

### DIFF
--- a/src/DynamoSamples.2013.sln
+++ b/src/DynamoSamples.2013.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleLibraryUI", "SampleLi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleLibraryZeroTouch", "SampleLibraryZeroTouch\SampleLibraryZeroTouch.csproj", "{BD13C4DC-9045-4E49-B637-B6182B0E3A7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZeroTouchEssentials", "ZeroTouchEssentials\ZeroTouchEssentials.csproj", "{F9ECE223-0EB7-41A5-8B19-ED51A9D3019A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{BD13C4DC-9045-4E49-B637-B6182B0E3A7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BD13C4DC-9045-4E49-B637-B6182B0E3A7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BD13C4DC-9045-4E49-B637-B6182B0E3A7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9ECE223-0EB7-41A5-8B19-ED51A9D3019A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9ECE223-0EB7-41A5-8B19-ED51A9D3019A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9ECE223-0EB7-41A5-8B19-ED51A9D3019A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9ECE223-0EB7-41A5-8B19-ED51A9D3019A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ZeroTouchEssentials/Properties/AssemblyInfo.cs
+++ b/src/ZeroTouchEssentials/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ZeroTouchEssentials")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ZeroTouchEssentials")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0388b517-f91d-442f-9629-5f23535bdd5d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ZeroTouchEssentials/ZeroTouchEssentials.cs
+++ b/src/ZeroTouchEssentials/ZeroTouchEssentials.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.DesignScript.Runtime;
+using Autodesk.DesignScript.Interfaces;
+using Autodesk.DesignScript.Geometry;
+
+///////////////////////////////////////////////////////////////////
+/// NOTE: This project requires references to the ProtoInterface
+/// and ProtoGeometry DLLs. These are found in the Dynamo install
+/// directory.
+///////////////////////////////////////////////////////////////////
+
+namespace ZeroTouchEssentials
+{
+    public class ZeroTouchEssentials
+    {
+        // Two private variables for example purposes
+        private double _a;
+        private double _b;
+
+        // We make the constructor for this object internal because the 
+        // Dynamo user should construct an object through a static method
+        internal ZeroTouchEssentials(double a, double b)
+        {
+            _a = a;
+            _b = b;
+        }
+
+        /// <summary>
+        /// An example of how to construct an object via a static method.
+        /// This is needed as Dynamo lacks a "new" keyword to construct a 
+        /// new object
+        /// </summary>
+        /// <param name="a">1st number. This will be stored in the Class.</param>
+        /// <param name="b">2nd number. This will be stored in the Class</param>
+        /// <returns>A newly-constructed ZeroTouchEssentials object</returns>
+        public static ZeroTouchEssentials ByTwoDoubles(double a, double b)
+        {
+            return new ZeroTouchEssentials(a, b);
+        }
+
+        /// <summary>
+        /// Example property returning the value _a inside the object
+        /// </summary>
+        public double A
+        {
+            get { return _a; }
+        }
+
+        /// <summary>
+        /// Example property returning the value _b inside the object
+        /// </summary>
+        public double B
+        {
+            get { return _b; }
+        }
+
+        /// <summary>
+        ///     An example showing how to return multiple values from a Zero-Touch imported node
+        ///     The names in the attribute should match the keys in the returned dictionary.
+        /// </summary>
+        /// <param name="a">First number.</param>
+        /// <param name="b">Second number.</param>
+        /// <returns name="add">Number created by adding two inputs together.</returns>
+        /// <returns name="mult">Number created by multiplying two inputs together.</returns>
+        /// <search>example,multi</search>
+        [MultiReturn(new[] { "add", "mult" })]
+        public static Dictionary<string, object> ReturnMultiExample(double a, double b)
+        {
+            return new Dictionary<string, object>
+            {
+                { "add", (a + b) },
+                { "mult", (a * b) }
+            };
+        }
+
+        /// <summary>
+        /// This method demonstrates how to use a native geometry object from Dynamo
+        /// in a custom method
+        /// </summary>
+        /// <param name="curve">Input Curve. This can be of any type deriving from Curve, such as NurbsCurve, Arc, Circle, etc</param>
+        /// <returns>The twice the length of the Curve </returns>
+        public static double DoubleLength(Autodesk.DesignScript.Geometry.Curve curve)
+        {
+            return curve.Length * 2.0;
+        }
+
+
+
+
+    }
+}

--- a/src/ZeroTouchEssentials/ZeroTouchEssentials.csproj
+++ b/src/ZeroTouchEssentials/ZeroTouchEssentials.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F9ECE223-0EB7-41A5-8B19-ED51A9D3019A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ZeroTouchEssentials</RootNamespace>
+    <AssemblyName>ZeroTouchEssentials</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ProtoGeometry">
+      <HintPath>..\..\..\Dynamo\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
+    </Reference>
+    <Reference Include="ProtoInterface">
+      <HintPath>..\..\..\Dynamo\extern\ProtoGeometry\ProtoInterface.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ZeroTouchEssentials.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
### Purpose

Reference: [MAGN-7224: Move the Zero-touch essentials library in DynamoDS/Dynamo](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7224)

This is a follow-up of the previous [pull request](https://github.com/DynamoDS/Dynamo/pull/5092) in the main Dynamo repository.

The ZeroTouchEssentials library is taken from @ptierney's [repository](https://github.com/ptierney/ZeroTouchEssentials) and is to be merged into DynamoSamples as a new project in the solution file.
### Reviewers

@sharadkjaiswal 
### FYIs

@ikeough 
