### PR TITLE
fixed path for CoreNodeModels.dll and changed output path for test 

### DIFF
--- a/src/SampleLibraryTests/SampleLibraryTests.csproj
+++ b/src/SampleLibraryTests/SampleLibraryTests.csproj
@@ -20,7 +20,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\Dynamo\bin\AnyCPU\Debug\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/SampleLibraryUI/SampleLibraryUI.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CoreNodeModels">
-      <HintPath>$(DynamoWpfUIPath)\CoreNodeModels.dll</HintPath>
+      <HintPath>$(DynamoWpfUINodesPath)\CoreNodeModels.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="CoreNodeModelsWpf">


### PR DESCRIPTION
Purpose:
This is PR is to fix build issues caused by file paths and to address [the following issue](https://github.com/DynamoDS/DynamoSamples/issues/11).
There are two scenarios:
1) Build release version with references to local dynamo repo
    Fix: modified path of CoreNodeModels of DynamoSamplesUI
2) Build debug version without references to dynamo repo (relying soley on packages)
    Fix: modified output path of DynamoSamplesTest to local debug folder

Reviewers:
@sharadkjaiswal 
