### PR TITLE
Update NuGet packages to 1.1.0

### DIFF
--- a/src/SampleLibraryTests/HelloDynamoSystemTests.cs
+++ b/src/SampleLibraryTests/HelloDynamoSystemTests.cs
@@ -20,9 +20,11 @@ namespace SampleLibraryTests
     /// IMPORTANT! 
     /// System tests have dependencies on Dynamo core dlls. In 
     /// order for these tests to work, your test dll needs to be 
-    /// located in the Dynamo core directory. Set your build
-    /// output path to your Dynamo core directory, or add a copy step that
-    /// moves the output from this project to the Dynamo core directory.
+    /// located in the Dynamo core directory. The project currently assumes
+    /// that Dynamo is built in a directory adjacent to the DynamoSamples
+    /// repository, so a relative path is set to the debug build folder for Dynamo.
+    /// If your setup is different, then you will need to explicitly set the output path
+    /// to your Dynamo installation directory.
     /// </summary>
     [TestFixture]
     [IsVisibleInDynamoLibrary(false)]

--- a/src/SampleLibraryTests/SampleLibraryTests.csproj
+++ b/src/SampleLibraryTests/SampleLibraryTests.csproj
@@ -20,7 +20,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\..\Dynamo\bin\AnyCPU\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -88,7 +88,7 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/SampleLibraryTests/SampleLibraryTests.csproj
+++ b/src/SampleLibraryTests/SampleLibraryTests.csproj
@@ -36,33 +36,37 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CoreNodeModels">
-      <HintPath>$(DynamoWpfUINodesPath)\CoreNodeModels.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="CoreNodeModels, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\CoreNodeModels.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="CoreNodeModelsWpf">
-      <HintPath>$(DynamoWpfUINodesPath)\CoreNodeModelsWpf.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="CoreNodeModelsWpf, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\CoreNodeModelsWpf.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoCore">
-      <HintPath>$(DynamoCorePath)\DynamoCore.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DynamoCore, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoCore.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoCoreWpf">
-      <HintPath>$(DynamoWpfUIPath)\DynamoCoreWpf.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DynamoCoreWpf, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\DynamoCoreWpf.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoServices">
-      <HintPath>$(DynamoServicesPath)\DynamoServices.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DynamoServices, Version=1.1.0.2094, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.1.1.0\lib\net45\DynamoServices.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoShapeManager">
-      <HintPath>$(DynamoCorePath)\DynamoShapeManager.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DynamoShapeManager, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoShapeManager.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="DynamoUtilities">
-      <HintPath>$(DynamoCorePath)\DynamoUtilities.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DynamoUnits, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\DynamoUnits.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DynamoUtilities, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoUtilities.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Expression.Interactions.dll</HintPath>
@@ -88,13 +92,13 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoCore">
-      <HintPath>$(DynamoCorePath)\ProtoCore.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ProtoCore, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\ProtoCore.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="ProtoGeometry">
-      <HintPath>$(DynamoZeroTouchPath)\ProtoGeometry.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\ProtoGeometry.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -103,13 +107,13 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Xaml" />
-    <Reference Include="SystemTestServices">
-      <HintPath>$(DynamoTestPackagePath)\SystemTestServices.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SystemTestServices, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Tests.1.1.0\lib\net45\SystemTestServices.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="TestServices">
-      <HintPath>$(DynamoTestPackagePath)\TestServices.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="TestServices, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Tests.1.1.0\lib\net45\TestServices.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/src/SampleLibraryTests/packages.config
+++ b/src/SampleLibraryTests/packages.config
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net4" />
-  <package id="DynamoVisualProgramming.Core" version="1.0.0-beta3" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.DynamoServices" version="1.0.0-beta3" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.Tests" version="1.0.0-beta4" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.WpfUILibrary" version="1.0.0-beta4" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.Core" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.DynamoServices" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.Tests" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.WpfUILibrary" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.1.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net4" />
   <package id="Prism" version="4.1.0.0" targetFramework="net4" />
 </packages>

--- a/src/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/SampleLibraryUI/SampleLibraryUI.csproj
@@ -41,32 +41,36 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CoreNodeModels">
-      <HintPath>$(DynamoWpfUINodesPath)\CoreNodeModels.dll</HintPath>
+    <Reference Include="CoreNodeModels, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\CoreNodeModels.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="CoreNodeModelsWpf">
-      <HintPath>$(DynamoWpfUIPath)\CoreNodeModelsWpf.dll</HintPath>
+    <Reference Include="CoreNodeModelsWpf, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\CoreNodeModelsWpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoCore">
-      <HintPath>$(DynamoCorePath)\DynamoCore.dll</HintPath>
+    <Reference Include="DynamoCore, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoCoreWpf">
-      <HintPath>$(DynamoWpfUIPath)\DynamoCoreWpf.dll</HintPath>
+    <Reference Include="DynamoCoreWpf, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\DynamoCoreWpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoServices">
-      <HintPath>$(DynamoServicesPath)\DynamoServices.dll</HintPath>
+    <Reference Include="DynamoServices, Version=1.1.0.2094, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.1.1.0\lib\net45\DynamoServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoShapeManager">
-      <HintPath>$(DynamoCorePath)\DynamoShapeManager.dll</HintPath>
+    <Reference Include="DynamoShapeManager, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoShapeManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoUtilities">
-      <HintPath>$(DynamoCorePath)\DynamoUtilities.dll</HintPath>
+    <Reference Include="DynamoUnits, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\DynamoUnits.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DynamoUtilities, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoUtilities.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -91,12 +95,12 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoCore">
-      <HintPath>$(DynamoCorePath)\ProtoCore.dll</HintPath>
+    <Reference Include="ProtoCore, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\ProtoCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ProtoGeometry">
-      <HintPath>$(DynamoZeroTouchPath)\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\ProtoGeometry.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SampleLibraryUI/packages.config
+++ b/src/SampleLibraryUI/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.0" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.Core" version="1.0.0-beta3" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.WpfUILibrary" version="1.0.0-beta4" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.Core" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.DynamoServices" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.WpfUILibrary" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.1.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="Prism" version="4.1.0.0" targetFramework="net45" />
 </packages>

--- a/src/SampleLibraryZeroTouch/SampleLibraryZeroTouch.csproj
+++ b/src/SampleLibraryZeroTouch/SampleLibraryZeroTouch.csproj
@@ -38,12 +38,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DynamoServices">
-      <HintPath>$(DynamoServicesPath)\DynamoServices.dll</HintPath>
+    <Reference Include="DynamoServices, Version=1.1.0.2094, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.1.1.0\lib\net45\DynamoServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ProtoGeometry">
-      <HintPath>$(DynamoZeroTouchPath)\ProtoGeometry.dll</HintPath>
+    <Reference Include="DynamoUnits, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\DynamoUnits.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\ProtoGeometry.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SampleLibraryZeroTouch/packages.config
+++ b/src/SampleLibraryZeroTouch/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.0.0-beta3" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.DynamoServices" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.1.0" targetFramework="net45" />
 </packages>

--- a/src/SampleViewExtension/SampleViewExtension.csproj
+++ b/src/SampleViewExtension/SampleViewExtension.csproj
@@ -34,32 +34,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CoreNodeModels">
-      <HintPath>$(DynamoWpfUIPath)\CoreNodeModels.dll</HintPath>
+    <Reference Include="CoreNodeModels, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\CoreNodeModels.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="CoreNodeModelsWpf">
-      <HintPath>$(DynamoWpfUIPath)\CoreNodeModelsWpf.dll</HintPath>
+    <Reference Include="CoreNodeModelsWpf, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\CoreNodeModelsWpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoCore">
-      <HintPath>$(DynamoCorePath)\DynamoCore.dll</HintPath>
+    <Reference Include="DynamoCore, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoCoreWpf">
-      <HintPath>$(DynamoWpfUIPath)\DynamoCoreWpf.dll</HintPath>
+    <Reference Include="DynamoCoreWpf, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.1.1.0\lib\net45\DynamoCoreWpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoServices">
-      <HintPath>$(DynamoServicesPath)\DynamoServices.dll</HintPath>
+    <Reference Include="DynamoServices, Version=1.1.0.2094, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.1.1.0\lib\net45\DynamoServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoShapeManager">
-      <HintPath>$(DynamoCorePath)\DynamoShapeManager.dll</HintPath>
+    <Reference Include="DynamoShapeManager, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoShapeManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoUtilities">
-      <HintPath>$(DynamoCorePath)\DynamoUtilities.dll</HintPath>
+    <Reference Include="DynamoUnits, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\DynamoUnits.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="DynamoUtilities, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\DynamoUtilities.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -86,12 +90,12 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoCore">
-      <HintPath>$(DynamoCorePath)\ProtoCore.dll</HintPath>
+    <Reference Include="ProtoCore, Version=1.1.0.2177, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.Core.1.1.0\lib\net45\ProtoCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ProtoGeometry">
-      <HintPath>$(DynamoZeroTouchPath)\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.1.1.0\lib\net45\ProtoGeometry.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SampleViewExtension/packages.config
+++ b/src/SampleViewExtension/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.0" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.Core" version="1.0.0-beta3" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.WpfUILibrary" version="1.0.0-beta4" targetFramework="net45" />
-  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.0.0-beta3" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.Core" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.DynamoServices" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.WpfUILibrary" version="1.1.0" targetFramework="net45" />
+  <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.1.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="Prism" version="4.1.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR updates the Dynamo NuGet packages to the latest stable version, 1.1.0. It also makes a slight change to assume that Dynamo is installed adjacent to this repo, so a relative build path to Dynamo's directory is set, which is required for the system tests to run.

FYI @tatlin 
