### PR TITLE
Fix ViewExtension Sample Bug

### DIFF
--- a/src/SampleViewExtension/SampleWindow.xaml
+++ b/src/SampleViewExtension/SampleWindow.xaml
@@ -10,6 +10,6 @@
     <Grid Name="MainGrid" 
           HorizontalAlignment="Stretch"
           VerticalAlignment="Stretch">
-            <TextBlock HorizontalAlignment="Stretch" Text="{Binding SelectedNodesText}" FontWeight="Bold" FontSize="24"/>
+            <TextBlock HorizontalAlignment="Stretch" Text="{Binding ActiveNodeTypes}" FontWeight="Bold" FontSize="24"/>
     </Grid>
 </Window>

--- a/src/SampleViewExtension/SampleWindowViewModel.cs
+++ b/src/SampleViewExtension/SampleWindowViewModel.cs
@@ -7,10 +7,32 @@ namespace SampleViewExtension
 {
     public class SampleWindowViewModel : NotificationObject, IDisposable
     {
-        private string selectedNodesText = "Begin selecting ";
+        private string activeNodeTypes;
         private ReadyParams readyParams;
 
-        public string SelectedNodesText = @"There are {readyParams.CurrentWorkspaceModel.Nodes.Count()} nodes in the workspace.";
+        // Displays active nodes in the workspace
+        public string ActiveNodeTypes
+        {
+            get
+            {
+                activeNodeTypes = getNodeTypes();
+                return activeNodeTypes;
+            }
+        }
+
+        // Helper function that builds string of active nodes
+        public string getNodeTypes()
+        {
+            string output = "Active nodes:\n";
+
+            foreach (NodeModel node in readyParams.CurrentWorkspaceModel.Nodes)
+            {
+                string nickName = node.Name;
+                output += nickName + "\n";
+            }
+
+            return output;
+        }
 
         public SampleWindowViewModel(ReadyParams p)
         {
@@ -21,7 +43,7 @@ namespace SampleViewExtension
 
         private void CurrentWorkspaceModel_NodesChanged(NodeModel obj)
         {
-            RaisePropertyChanged("SelectedNodesText");
+            RaisePropertyChanged("ActiveNodeTypes");
         }
 
         public void Dispose()


### PR DESCRIPTION
### Purpose

This PR addresses a bug in the view extension sample.  Line 13 of `SampleWindowViewModel.cs`
was originally using C# 6.0 but was later updated to a string literal prefixed with `@` preventing the function that does the work from ever being called.  We also now return all the active nodes on the canvas instead of just the node count.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@Racel 