### PR TITLE
[IsVisibleInDynamoLibrary(false)] attribute is applied only to outer class, however inherited class is still imported

### DIFF
--- a/src/SampleLibraryZeroTouch/Examples/TraceExample.cs
+++ b/src/SampleLibraryZeroTouch/Examples/TraceExample.cs
@@ -147,6 +147,7 @@ namespace Examples
 
     [IsVisibleInDynamoLibrary(false)]
     [Serializable]
+    [SupressImportIntoVM]
     public class TraceableId : ISerializable
     {
         public int IntID { get; set; }


### PR DESCRIPTION
Related to: [Dynamo Core Issue 8789](https://github.com/DynamoDS/Dynamo/issues/8789)

The `[IsVisibleInDynamoLibrary(false)]` attribute is applied only to outer class, however the inherited class is still being imported.  This is a regression in 2.0 and is being tracked with [QNTM-4094](https://jira.autodesk.com/browse/QNTM-4094).  This fix prevents the extra categories and node from appearing in the package in the library but is not a fix for the task above.

This PR prevents `GetObjectData` from appearing in the library as shown below.  Periodic nodes are the only nodes in the repo that use this class and I have verified that they still run, serialize, and deserialize correctly.

Before:
![image](https://user-images.githubusercontent.com/13341935/41680273-f2d9810a-749e-11e8-8228-9e0f51c698a1.png)

After:
![image](https://user-images.githubusercontent.com/13341935/41680187-b14a0840-749e-11e8-9254-0a5060fe824d.png)


Periodic Update:
![using_trace](https://user-images.githubusercontent.com/13341935/41680134-7a124a7c-749e-11e8-9b7f-5152f9f79fa2.gif)

### Reviewer
@mjkkirschner 