### PR TITLE
DefaultArgumentAttribute should use fully qualified naming

### DIFF
--- a/src/SampleLibraryZeroTouch/Examples/BasicExample.cs
+++ b/src/SampleLibraryZeroTouch/Examples/BasicExample.cs
@@ -119,7 +119,7 @@ namespace Examples
         /// </summary>
         /// <param name="point">A point.</param>
         /// <returns>A BasicExample object.</returns>
-        public static BasicExample Create([DefaultArgumentAttribute("Point.ByCoordinates(5,5,5);")]Point point)
+        public static BasicExample Create([DefaultArgumentAttribute("Autodesk.DesignScript.Geometry.Point.ByCoordinates(5,5,5);")]Point point)
         {
             return new BasicExample(point.X, point.Y, point.Z);
         }


### PR DESCRIPTION
### Purpose
`DefaultArgumentAttribute` should use fully qualified naming to avoid namespace conflicts.

### Reviewers
@mjkkirschner 
@aparajit-pratap 