### PR TITLE
Return the correct selection state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ local.properties
 *.suo
 *.user
 *.sln.docstates
+.vs
 
 # Build results
 

--- a/src/SampleLibraryUI/Examples/DropDown.cs
+++ b/src/SampleLibraryUI/Examples/DropDown.cs
@@ -49,7 +49,7 @@ namespace SampleLibraryUI.Examples
             // has a pre-selection.
 
             SelectedIndex = 0;
-            return SelectionState.Done;
+            return SelectionState.Restore;
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)

--- a/src/SampleViewExtension/SampleViewExtension.csproj
+++ b/src/SampleViewExtension/SampleViewExtension.csproj
@@ -161,10 +161,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy "$(ProjectDir)bin\Debug\SampleViewExtension.dll" "$(ProjectDir)..\..\dynamo_viewExtension\Sample View Extension\bin" /Y /E
-xcopy "$(ProjectDir)bin\Debug\SampleViewExtension_ViewExtensionDefinition.xml" "$(ProjectDir)..\..\dynamo_viewExtension\Sample View Extension\extra" /Y /E</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <PackageDll Include="$(ProjectDir)bin\$(ConfigurationName)\SampleViewExtension.dll" />
+      <PackageXml Include="$(ProjectDir)bin\$(ConfigurationName)\SampleViewExtension_ViewExtensionDefinition.xml" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PackageDll)" DestinationFolder="$(ProjectDir)..\..\dynamo_viewExtension\Sample View Extension\bin" />
+    <Copy SourceFiles="@(PackageXml)" DestinationFolder="$(ProjectDir)..\..\dynamo_viewExtension\Sample View Extension\extra" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
@alfarok @mjkkirschner Find this bug when working on test in DynamoCore referencing the dropdown in this package. 

From the description, `Restore` should be return unless we add logic in this class about how to set SelectedIndex
```C#
        protected enum SelectionState
        {
            /// <summary>
            /// Derived class has determined the best selection. 
            /// Base class will not attempt to select another item.
            /// </summary>
            Done,

            /// <summary>
            /// Derived class could not determine the right selection
            /// and it is left to the base class to restore the previous 
            /// selection if there was one.
            /// </summary>
            Restore
        }
```