### PR TITLE
Add localized customNodeModel sample

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ platform: Any CPU
 configuration: Release
 
 build:
-  project: src/DynamoSamples.2013.sln
+  project: src/DynamoSamples.sln
   verbosity: normal
   
 test: off
 
 before_build:
-  - nuget restore .\src\DynamoSamples.2013.sln
+  - nuget restore .\src\DynamoSamples.sln

--- a/src/SampleExtension/Extension.cs
+++ b/src/SampleExtension/Extension.cs
@@ -35,7 +35,7 @@ namespace SampleExtension
         {
             get
             {
-                "49fee64a-4505-4f03-a6b6-0667a793f19a"
+                return "49fee64a-4505-4f03-a6b6-0667a793f19a";
             }
         }
 

--- a/src/SampleLibraryUI/Examples/LocalizedCustomNodeModel.cs
+++ b/src/SampleLibraryUI/Examples/LocalizedCustomNodeModel.cs
@@ -1,0 +1,39 @@
+﻿using Dynamo.Graph.Nodes;
+using Newtonsoft.Json;
+using ProtoCore.AST.AssociativeAST;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SampleLibraryUI.Examples
+{
+    /// <summary>
+    /// This example node uses .net .resx files and generated sattelite assemblies to perform runtime lookup of localized content
+    /// depending on the culture of the system Dynamo is running on.
+    /// Read more: https://docs.microsoft.com/en-us/dotnet/framework/resources/creating-resource-files-for-desktop-apps
+    /// You can use the -l "es-ES" flag when starting DynamoSandbox.exe to replace the English strings with Spanish ones.
+    /// </summary>
+    [NodeName("LocalizedNode")]
+    [NodeDescription("CustomNodeModelDescription", typeof(Properties.Resources))]
+    [OutPortNames("string")]
+    [OutPortTypes("string")]
+    [IsDesignScriptCompatible]
+    public class LocalizedCustomNodeModel : NodeModel
+    {
+        public LocalizedCustomNodeModel()
+        {
+            RegisterAllPorts();
+        }
+
+        [JsonConstructor]
+        public LocalizedCustomNodeModel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+
+        public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
+        {
+            //return a localized string, that is defined in the resx file/resource assembly.
+            return new List<AssociativeNode> { AstFactory.BuildAssignment(this.AstIdentifierForPreview, AstFactory.BuildPrimitiveNodeFromObject(Properties.Resources.LocalStringResult)) };
+        }
+    }
+}

--- a/src/SampleLibraryUI/Properties/Resources.Designer.cs
+++ b/src/SampleLibraryUI/Properties/Resources.Designer.cs
@@ -86,5 +86,14 @@ namespace SampleLibraryUI.Properties {
                 return ResourceManager.GetString("CustomNodeModelPortDataOutputToolTip", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to I am a localized string..
+        /// </summary>
+        internal static string LocalStringResult {
+            get {
+                return ResourceManager.GetString("LocalStringResult", resourceCulture);
+            }
+        }
     }
 }

--- a/src/SampleLibraryUI/Properties/Resources.es-ES.resx
+++ b/src/SampleLibraryUI/Properties/Resources.es-ES.resx
@@ -118,16 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CustomNodeModelDescription" xml:space="preserve">
-    <value>A sample UI node which displays custom UI.</value>
-    <comment>Description for Hello Dynamo</comment>
-  </data>
-  <data name="CustomNodeModePortDataInputToolTip" xml:space="preserve">
-    <value>Input a string.</value>
-  </data>
-  <data name="CustomNodeModePortDataOutputToolTip" xml:space="preserve">
-    <value>A result.</value>
+    <value>Un nodo de interfaz de usuario de muestra que muestra una interfaz de usuario personalizada.</value>
   </data>
   <data name="LocalStringResult" xml:space="preserve">
-    <value>I am a localized string.</value>
+    <value>Soy una cadena localizada.</value>
   </data>
 </root>

--- a/src/SampleLibraryUI/Properties/Resources.resx
+++ b/src/SampleLibraryUI/Properties/Resources.resx
@@ -127,4 +127,7 @@
   <data name="CustomNodeModelPortDataOutputToolTip" xml:space="preserve">
     <value>A result.</value>
   </data>
+  <data name="LocalStringResult" xml:space="preserve">
+    <value>I am a localized string.</value>
+  </data>
 </root>

--- a/src/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/SampleLibraryUI/SampleLibraryUI.csproj
@@ -151,6 +151,7 @@
     </Compile>
     <Compile Include="Examples\ButtonCustomNodeModel.cs" />
     <Compile Include="Examples\DropDown.cs" />
+    <Compile Include="Examples\LocalizedCustomNodeModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Examples\SliderCustomNodeModel.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
@@ -175,6 +176,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Properties\Resources.es-ES.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
@@ -209,9 +211,11 @@
   <Target Name="AfterBuild">
     <ItemGroup>
       <PackageFiles Include="$(OutDir)\SampleLibraryUI.dll;$(OutDir)\SampleLibraryUI.XML;$(OutDir)\SampleLibraryUI.dll.config" />
-      <ResourceFiles Include="$(OutDir)\en-US\*.*" />
+      <ENResourceFiles Include="$(OutDir)\en-US\*.*" />
+      <ESResourceFiles Include="$(OutDir)\es-ES\*.*" />
     </ItemGroup>
     <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(SolutionDir)..\dynamo_package\Dynamo Samples\bin\" />
-    <Copy SourceFiles="@(ResourceFiles)" DestinationFolder="$(SolutionDir)..\dynamo_package\Dynamo Samples\bin\en-US" />
+    <Copy SourceFiles="@(ENResourceFiles)" DestinationFolder="$(SolutionDir)..\dynamo_package\Dynamo Samples\bin\en-US" />
+    <Copy SourceFiles="@(ESResourceFiles)" DestinationFolder="$(SolutionDir)..\dynamo_package\Dynamo Samples\bin\es-ES" />
   </Target>
 </Project>


### PR DESCRIPTION
![Screen Shot 2021-04-22 at 4 40 00 PM](https://user-images.githubusercontent.com/508936/115782417-a9d3a900-a389-11eb-9490-6632ff76cb93.png)

This PR adds a new `CustomNodeModel` sample that uses the resource manager to lookup localized strings at runtime. I've tested it in DynamoSandbox by using the `-l` flag to switch on spanish culture localization.

PR also fixes the build because of an edit I had made previously, and attempts to fix the old appveyor build xaml.

TODO - I'll probably send another PR for an issue with the sampleTests project that breaks builds of Dynamo by copying old nuget binaries around.
