### PR TITLE
Fix Build by Removal of extra references

### DIFF
--- a/src/SampleExtension/SampleExtension.csproj
+++ b/src/SampleExtension/SampleExtension.csproj
@@ -141,11 +141,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="images\logo.png" />
     <Content Include="SampleExtension_ExtensionDefinition.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/SampleLibraryTests/SampleLibraryTests.csproj
+++ b/src/SampleLibraryTests/SampleLibraryTests.csproj
@@ -145,7 +145,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="HelloDynamoSystemTest.dyn">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -153,9 +152,6 @@
     <None Include="TestServices.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="images\logo.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">

--- a/src/SampleLibraryZeroTouch/SampleLibraryZeroTouch.csproj
+++ b/src/SampleLibraryZeroTouch/SampleLibraryZeroTouch.csproj
@@ -144,11 +144,7 @@
     <Compile Include="Examples\TraceExample.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="images\logo.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Fix build by removal of extra references brought in by Visual Studio when updating nugets