### PR TITLE
Cleanup culture flag

### DIFF
--- a/src/Config/CS.props
+++ b/src/Config/CS.props
@@ -9,7 +9,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <UICulture>en-US</UICulture>
     <OutputType Condition=" '$(OutputType)' == '' ">Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>


### PR DESCRIPTION
I added the `UICulture` while trying to fix the samples tests and forgot to remove it.
When used, UICulture will cause a resource file to be generated, which if missing will cause errors at component init time.